### PR TITLE
Add possibilty to verify a signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ the [signer device
 app](https://github.com/tillitis/tkey-device-signer) for the actual
 signatures.
 
+It can also verify a signature, by supplying the message, signature
+and the public key.
+
 It is currently just a test tool and can take at most 4 kiB large
 files.
 
@@ -17,10 +20,20 @@ See [Release notes](RELEASE.md).
 ### Usage
 
 ```
-$ tkey-sign [flags...] [FILE]
+$ tkey-sign <command> [flags...] FILE...
 ```
 
-Options are:
+Commands are:
+```
+  sign        Create a signature
+  verify      Verify a signature
+```
+
+Usage for the sign-command are:
+```
+$ tkey-sign sign [flags...] FILE
+```
+with options:
 
 ```
   -p, --show-pubkey     Don't sign anything, only output the public key.
@@ -36,7 +49,12 @@ Options are:
                         (dash) to read from stdin. The full contents are hashed
                         unmodified (e.g. newlines are not stripped).
       --verbose         Enable verbose output.
-      --help            Output this help.
+  -h, --help            Output this help.
+```
+
+Usage for the verify-command are:
+```
+$ tkey-sign verify FILE SIG-FILE PUBKEY-FILE
 ```
 
 ## Building

--- a/main.go
+++ b/main.go
@@ -4,8 +4,10 @@
 package main
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	_ "embed"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -66,7 +68,7 @@ func isWantedApp(signer tkeysign.Signer) bool {
 		nameVer.Name1 == wantAppName1
 }
 
-// signFile returns ed25519 signature
+// signFile returns Ed25519 signature
 func signFile(signer tkeysign.Signer, pubkey []byte, fileName string) ([]byte, error) {
 	message, err := os.ReadFile(fileName)
 	if err != nil {
@@ -95,72 +97,52 @@ func signFile(signer tkeysign.Signer, pubkey []byte, fileName string) ([]byte, e
 	return signature, nil
 }
 
-func main() {
-	var fileName, fileUSS, devPath string
-	var speed int
-	var enterUSS, showPubkeyOnly, verbose, helpOnly bool
-	pflag.CommandLine.SetOutput(os.Stderr)
-	pflag.CommandLine.SortFlags = false
-	pflag.BoolVarP(&showPubkeyOnly, "show-pubkey", "p", false,
-		"Don't sign anything, only output the public key.")
-	pflag.StringVar(&devPath, "port", "",
-		"Set serial port device `PATH`. If this is not passed, auto-detection will be attempted.")
-	pflag.IntVar(&speed, "speed", tkeyclient.SerialSpeed,
-		"Set serial port speed in `BPS` (bits per second).")
-	pflag.BoolVar(&enterUSS, "uss", false,
-		"Enable typing of a phrase to be hashed as the User Supplied Secret. The USS is loaded onto the TKey along with the app itself. A different USS results in different public/private keys, meaning a different identity.")
-	pflag.StringVar(&fileUSS, "uss-file", "",
-		"Read `FILE` and hash its contents as the USS. Use '-' (dash) to read from stdin. The full contents are hashed unmodified (e.g. newlines are not stripped).")
-	pflag.BoolVar(&verbose, "verbose", false, "Enable verbose output.")
-	pflag.BoolVar(&helpOnly, "help", false, "Output this help.")
-	pflag.Usage = func() {
-		desc := fmt.Sprintf(`Usage: %[1]s [flags...] [FILE]
-
-%[1]s communicates with the signer app running on Tillitis TKey and
-makes it sign data provided in FILE (the "message"). The message can be at most
-4096 bytes long. The signature made by the signer app is always output on stdout.
-Exit status code is 0 if everything went well and the signature also can be
-verified using the public key. Otherwise exit code is non-zero.
-
-Alternatively, --show-pubkey can be used to only output (on stdout) the
-public key of the signer app on the TKey.`, os.Args[0])
-		le.Printf("%s\n\n%s", desc,
-			pflag.CommandLine.FlagUsagesWrapped(86))
-	}
-	pflag.Parse()
-
-	if pflag.NArg() > 0 {
-		if pflag.NArg() > 1 {
-			le.Printf("Unexpected argument: %s\n\n", strings.Join(pflag.Args()[1:], " "))
-			pflag.Usage()
-			os.Exit(2)
-		}
-		fileName = pflag.Args()[0]
+// fileInputToHex reads inputFile and returns a trimmed slice decoded to hex.
+func fileInputToHex(inputFile string) ([]byte, error) {
+	input, err := os.ReadFile(inputFile)
+	if err != nil {
+		return nil, fmt.Errorf("could not read %s: %w", inputFile, err)
 	}
 
-	if helpOnly {
-		pflag.Usage()
-		os.Exit(0)
+	input = bytes.Trim(input, "\n")
+	hexOutput := make([]byte, hex.DecodedLen(len(input)))
+	_, err = hex.Decode(hexOutput, input)
+	if err != nil {
+		return nil, fmt.Errorf("could not decode: %w", err)
+	}
+	return hexOutput, nil
+}
+
+// verifySignature verifies a Ed25519 signature from input files of message, signature and public key
+func verifySignature(fileMessage string, fileSignature string, filePubkey string) error {
+	message, err := os.ReadFile(fileMessage)
+	if err != nil {
+		return fmt.Errorf("could not read %s: %w", fileMessage, err)
 	}
 
-	if fileName == "" && !showPubkeyOnly {
-		le.Printf("Please pass at least a message FILE, or -p.\n\n")
-		pflag.Usage()
-		os.Exit(2)
+	signature, err := fileInputToHex(fileSignature)
+	if err != nil {
+		return fmt.Errorf("decodeFileInput: %w", err)
 	}
 
-	if fileName != "" && showPubkeyOnly {
-		le.Printf("Pass only a message FILE or -p.\n\n")
-		pflag.Usage()
-		os.Exit(2)
+	pubkey, err := fileInputToHex(filePubkey)
+	if err != nil {
+		return fmt.Errorf("decodeFileInput: %w", err)
 	}
 
-	if enterUSS && fileUSS != "" {
-		le.Printf("Pass only one of --uss or --uss-file.\n\n")
-		pflag.Usage()
-		os.Exit(2)
+	fmt.Printf("Public key: %x\n", pubkey)
+	fmt.Printf("Signature: %x\n", signature)
+	fmt.Printf("Message length: %d\n", len(message))
+
+	if !ed25519.Verify(pubkey, message, signature) {
+		return fmt.Errorf("signature not valid")
 	}
 
+	return nil
+}
+
+// doSign connects to a TKey and signs the attached file
+func doSign(devPath string, verbose bool, fileName string, fileUSS string, enterUSS bool, showPubkeyOnly bool, speed int) error {
 	if !verbose {
 		tkeyclient.SilenceLogging()
 	}
@@ -169,15 +151,14 @@ public key of the signer app on the TKey.`, os.Args[0])
 		var err error
 		devPath, err = tkeyclient.DetectSerialPort(true)
 		if err != nil {
-			os.Exit(1)
+			return fmt.Errorf("DetectSerialPort: %w", err)
 		}
 	}
 
 	tk := tkeyclient.New()
 	le.Printf("Connecting to TKey on serial port %s ...\n", devPath)
 	if err := tk.Connect(devPath, tkeyclient.WithSpeed(speed)); err != nil {
-		le.Printf("Could not open %s: %v\n", devPath, err)
-		os.Exit(1)
+		return fmt.Errorf("could not open %s: %w", devPath, err)
 	}
 
 	if isFirmwareMode(tk) {
@@ -187,65 +168,57 @@ public key of the signer app on the TKey.`, os.Args[0])
 		if enterUSS {
 			secret, err = tkeyutil.InputUSS()
 			if err != nil {
-				le.Printf("InputUSS: %v", err)
-				os.Exit(1)
+				return fmt.Errorf("InputUSS: %w", err)
 			}
 		}
 		if fileUSS != "" {
 			secret, err = tkeyutil.ReadUSS(fileUSS)
 			if err != nil {
-				le.Printf("ReadUSS: %v", err)
-				os.Exit(1)
+				return fmt.Errorf("ReadUSS: %w", err)
 			}
 		}
 
 		if err := tk.LoadApp(signerBinary, secret); err != nil {
-			le.Printf("Couldn't load signer: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("couldn't load signer: %w", err)
 		}
 
 		le.Printf("Signer app loaded.\n")
-	} else if enterUSS || fileUSS != "" {
-		le.Printf("WARNING: App already loaded, your USS won't be used.")
+	} else {
+		if enterUSS || fileUSS != "" {
+			le.Printf("WARNING: App already loaded, your USS won't be used.")
+		} else {
+			le.Printf("WARNING: App already loaded.")
+		}
 	}
 
 	signer := tkeysign.New(tk)
-	exit := func(code int) {
-		if err := signer.Close(); err != nil {
-			le.Printf("%v\n", err)
-		}
-		os.Exit(code)
-	}
+	defer signer.Close()
 
-	handleSignals(func() { exit(1) }, os.Interrupt, syscall.SIGTERM)
+	handleSignals(func() { os.Exit(1) }, os.Interrupt, syscall.SIGTERM)
 
 	if !isWantedApp(signer) {
-		le.Printf("No TKey on the serial port, or it's running wrong app (and is not in firmware mode)")
-		tk.Close()
-		exit(1)
+		return fmt.Errorf("no TKey on the serial port, or it's running wrong app (and is not in firmware mode)")
 	}
 
 	pubkey, err := signer.GetPubkey()
 	if err != nil {
-		le.Printf("GetPubKey failed: %v\n", err)
-		exit(1)
+		return fmt.Errorf("GetPubKey failed: %w", err)
 	}
 	if showPubkeyOnly {
 		fmt.Printf("%x\n", pubkey)
-		exit(0)
+		return nil
 	}
 	le.Printf("Public Key from TKey: %x\n", pubkey)
 
 	signature, err := signFile(signer, pubkey, fileName)
 	if err != nil {
-		le.Printf("signing failed: %v", err)
-		exit(1)
+		return fmt.Errorf("signing faild: %w", err)
 	}
 
 	le.Printf("Signature over message by TKey (on stdout):\n")
 	fmt.Printf("%x\n", signature)
 
-	os.Exit(0)
+	return nil
 }
 
 func handleSignals(action func(), sig ...os.Signal) {
@@ -257,4 +230,169 @@ func handleSignals(action func(), sig ...os.Signal) {
 			action()
 		}
 	}()
+}
+
+func main() {
+	var fileName, fileUSS, fileSignature, filePubkey, devPath string
+	var speed int
+	var enterUSS, showPubkeyOnly, verbose, helpOnlySign, helpOnlyVerify bool
+
+	signString := "sign"
+	verifyString := "verify"
+
+	// Default text to show
+	root := pflag.NewFlagSet("root", pflag.ExitOnError)
+	root.Usage = func() {
+		desc := fmt.Sprintf(`%[1]s communicates with the signer app running on Tillitis TKey and
+makes it sign data provided in FILE (the "message"). The message can be at most
+4096 bytes long. The signature made by the signer app is always output on stdout.
+Exit status code is 0 if everything went well and the signature also can be
+verified using the public key. Otherwise exit code is non-zero.
+
+Usage:
+  %[1]s <command> [flags] FILE...
+
+Commands:
+  sign        Create a signature
+  verify      Verify a signature
+
+Use <command> --help for further help, i.e. %[1]s verify --help`, os.Args[0])
+		le.Printf("%s\n\n%s", desc,
+			root.FlagUsagesWrapped(86))
+	}
+
+	// Flag for command "sign"
+	cmdSign := pflag.NewFlagSet(signString, pflag.ExitOnError)
+	cmdSign.SortFlags = false
+	cmdSign.BoolVarP(&showPubkeyOnly, "show-pubkey", "p", false,
+		"Don't sign anything, only output the public key.")
+	cmdSign.StringVar(&devPath, "port", "",
+		"Set serial port device `PATH`. If this is not passed, auto-detection will be attempted.")
+	cmdSign.IntVar(&speed, "speed", tkeyclient.SerialSpeed,
+		"Set serial port speed in `BPS` (bits per second).")
+	cmdSign.BoolVar(&enterUSS, "uss", false,
+		"Enable typing of a phrase to be hashed as the User Supplied Secret. The USS is loaded onto the TKey along with the app itself. A different USS results in different public/private keys, meaning a different identity.")
+	cmdSign.StringVar(&fileUSS, "uss-file", "",
+		"Read `FILE` and hash its contents as the USS. Use '-' (dash) to read from stdin. The full contents are hashed unmodified (e.g. newlines are not stripped).")
+	cmdSign.BoolVar(&verbose, "verbose", false, "Enable verbose output.")
+	cmdSign.BoolVarP(&helpOnlySign, "help", "h", false, "Output this help.")
+	cmdSign.Usage = func() {
+		desc := fmt.Sprintf(`Usage: %[1]s sign [flags...] FILE
+
+  Signes the data provided in FILE (the "message") using the Tillitis TKey.
+  The message can be at most 4096 bytes long. The signature made by the signer
+  app is always output on stdout. Exit status code is 0 if everything went well
+  and the signature also can be verified using the public key. Otherwise exit
+  code is non-zero.
+
+  Alternatively, --show-pubkey can be used to only output (on stdout) the
+  public key of the signer app on the TKey.`, os.Args[0])
+		le.Printf("%s\n\n%s", desc,
+			cmdSign.FlagUsagesWrapped(86))
+	}
+
+	// Flag for command "verify"
+	cmdVerify := pflag.NewFlagSet(verifyString, pflag.ExitOnError)
+	cmdVerify.BoolVarP(&helpOnlyVerify, "help", "h", false, "Output this help.")
+	cmdVerify.Usage = func() {
+		desc := fmt.Sprintf(`Usage: %[1]s verify FILE SIG-FILE PUBKEY-FILE
+
+  Verifies wheather the Ed25519 signature of the FILE is valid, based on the input files
+  SIG-FILE and PUBKEY-FILE. Newlines will be striped from the input files. The return value
+  is zero if the signature is valid, otherwise non-zero.
+
+  Does not need a connected TKey to verify.`, os.Args[0])
+		le.Printf("%s\n\n%s", desc,
+			cmdVerify.FlagUsagesWrapped(86))
+	}
+
+	if len(os.Args) == 1 {
+		root.Usage()
+		os.Exit(2)
+	}
+
+	switch os.Args[1] {
+	case signString:
+		if err := cmdSign.Parse(os.Args[2:]); err != nil {
+			le.Printf("Error parsing input arguments: %v\n", err)
+			os.Exit(2)
+		}
+
+		if helpOnlySign {
+			cmdSign.Usage()
+			os.Exit(0)
+		}
+
+		if cmdSign.NArg() > 0 {
+			if cmdSign.NArg() > 1 {
+				le.Printf("Unexpected argument: %s\n\n", strings.Join(cmdSign.Args()[1:], " "))
+				cmdSign.Usage()
+				os.Exit(2)
+			}
+			fileName = cmdSign.Args()[0]
+		}
+
+		if fileName == "" && !showPubkeyOnly {
+			le.Printf("Please pass at least a message FILE, or -p.\n\n")
+			cmdSign.Usage()
+			os.Exit(2)
+		}
+
+		if fileName != "" && showPubkeyOnly {
+			le.Printf("Pass only a message FILE or -p.\n\n")
+			cmdSign.Usage()
+			os.Exit(2)
+		}
+
+		if enterUSS && fileUSS != "" {
+			le.Printf("Pass only one of --uss or --uss-file.\n\n")
+			cmdSign.Usage()
+			os.Exit(2)
+		}
+
+		err := doSign(devPath, verbose, fileName, fileUSS, enterUSS, showPubkeyOnly, speed)
+		if err != nil {
+			le.Printf("Error signing: %v\n", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+
+	case verifyString:
+		if err := cmdVerify.Parse(os.Args[2:]); err != nil {
+			le.Printf("Error parsing input arguments: %v\n", err)
+			os.Exit(2)
+		}
+
+		if helpOnlyVerify {
+			cmdVerify.Usage()
+			os.Exit(0)
+		}
+
+		if cmdVerify.NArg() < 3 {
+			le.Printf("Missing %d input file(s) to verify signature.\n\n", 3-cmdVerify.NArg())
+			cmdVerify.Usage()
+			os.Exit(2)
+		} else if cmdVerify.NArg() > 3 {
+			le.Printf("Unexpected argument: %s\n\n", strings.Join(cmdVerify.Args()[3:], " "))
+			cmdVerify.Usage()
+			os.Exit(2)
+		}
+		fileName = cmdVerify.Args()[0]
+		fileSignature = cmdVerify.Args()[1]
+		filePubkey = cmdVerify.Args()[2]
+
+		le.Printf("Verifying signature ...\n")
+		if err := verifySignature(fileName, fileSignature, filePubkey); err != nil {
+			le.Printf("Error verifying: %v\n", err)
+			os.Exit(1)
+		}
+		le.Printf("Signature verified.\n")
+		os.Exit(0)
+
+	default:
+		root.Usage()
+		le.Printf("%q is not a valid subcommand.\n", os.Args[1])
+		os.Exit(2)
+	}
+	os.Exit(1) // should never be reached
 }


### PR DESCRIPTION
New commands implemented;
- ./tkey-sign sign <flags> FILE
- ./tkey-sign verify FILE ...

Verify takes a message in FILE, a signature in SIG-FILE and a pubkey in PUBKEY-FILE
