### PR TITLE
Sign & verify arbitrary long files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,21 +3,18 @@
 
 # tkey-sign
 
-`tkey-sign` is a command to do a cryptographic signature (ed25519)
-over a file using the [Tillitis](https://tillitis.se/) TKey. It uses
-the [signer device
+`tkey-sign` is a utility that can do and verify an Ed25519
+cryptographic signature over a digest of a file using the
+[Tillitis](https://tillitis.se/) TKey. It uses the [signer device
 app](https://github.com/tillitis/tkey-device-signer) for the actual
 signatures.
 
-It can also verify a signature, by supplying the message, signature
-and the public key.
-
-It is currently just a test tool and can take at most 4 kiB large
-files.
+It can also verify a signature by passing files with the message,
+signature, and the public key as arguments.
 
 See [Release notes](RELEASE.md).
 
-### Usage
+## Usage
 
 ```
 $ tkey-sign <command> [flags...] FILE...

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## unreleased
+
+Added functionality to sign arbitrary large files
+
 ## v0.0.7
 
 Migrated from https://github.com/tillitis/tillitis-key1-apps/

--- a/go.mod
+++ b/go.mod
@@ -3,21 +3,21 @@ module tkey-sign
 go 1.20
 
 require (
-	github.com/gen2brain/beeep v0.0.0-20230602101333-f384c29b62dd
-	github.com/go-toast/toast v0.0.0-20190211030409-01e6764cf0a4
 	github.com/spf13/pflag v1.0.5
 	github.com/tillitis/tkeyclient v0.0.0-20230607181239-48de67d61ab9
 	github.com/tillitis/tkeysign v0.0.7
-	go.bug.st/serial v1.5.0
-	golang.org/x/sys v0.9.0
-	golang.org/x/term v0.9.0
+	github.com/tillitis/tkeyutil v0.0.7
 )
 
 require (
 	github.com/creack/goselect v0.1.2 // indirect
+	github.com/gen2brain/beeep v0.0.0-20230602101333-f384c29b62dd // indirect
+	github.com/go-toast/toast v0.0.0-20190211030409-01e6764cf0a4 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d // indirect
 	github.com/tadvi/systray v0.0.0-20190226123456-11a2b8fa57af // indirect
-	github.com/tillitis/tkeyutil v0.0.0-20230601165544-6d4b739494a2 // indirect
-	golang.org/x/crypto v0.7.0 // indirect
+	go.bug.st/serial v1.5.0 // indirect
+	golang.org/x/crypto v0.10.0 // indirect
+	golang.org/x/sys v0.9.0 // indirect
+	golang.org/x/term v0.9.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -19,12 +19,12 @@ github.com/tillitis/tkeyclient v0.0.0-20230607181239-48de67d61ab9 h1:IE3xwhK/i9y
 github.com/tillitis/tkeyclient v0.0.0-20230607181239-48de67d61ab9/go.mod h1:LJF9olZ1FL4zIvDY4OoKSp/9YiQY0e8JoKLo0Wg1+Zc=
 github.com/tillitis/tkeysign v0.0.7 h1:7Y9E5UgSfuaPcvxhkcgRB//fA4PHbqNWtNcNXTgE1z0=
 github.com/tillitis/tkeysign v0.0.7/go.mod h1:sEDRw2sHyXT1CojrTViorg98dpI3L1G+TBhZrkNba7Y=
-github.com/tillitis/tkeyutil v0.0.0-20230601165544-6d4b739494a2 h1:oCNPwncK9CNqEkFjr7Ia8QrsLSRftpj9PqsgV14d6pI=
-github.com/tillitis/tkeyutil v0.0.0-20230601165544-6d4b739494a2/go.mod h1:KI+trqptqoe+7hQaryBxgRENZPb24NrPlLexIFd/dFU=
+github.com/tillitis/tkeyutil v0.0.7 h1:+QE4hvthUextFDiLt8Ssxffyn0FPNwDcloahS0sPSQU=
+github.com/tillitis/tkeyutil v0.0.7/go.mod h1:KI+trqptqoe+7hQaryBxgRENZPb24NrPlLexIFd/dFU=
 go.bug.st/serial v1.5.0 h1:ThuUkHpOEmCVXxGEfpoExjQCS2WBVV4ZcUKVYInM9T4=
 go.bug.st/serial v1.5.0/go.mod h1:UABfsluHAiaNI+La2iESysd9Vetq7VRdpxvjx7CmmOE=
-golang.org/x/crypto v0.7.0 h1:AvwMYaRytfdeVt3u6mLaxYtErKYjxA2OXjJ1HHq6t3A=
-golang.org/x/crypto v0.7.0/go.mod h1:pYwdfH91IfpZVANVyUOhSIPZaFoJGxTFbZhFTx+dXZU=
+golang.org/x/crypto v0.10.0 h1:LKqV2xt9+kDzSTfOhx4FrkEBcMrAgHSYgzywV9zcGmM=
+golang.org/x/crypto v0.10.0/go.mod h1:o4eNf7Ede1fv+hwOwZsTHl9EsPFO6q6ZvYR8vYfY45I=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.9.0 h1:KS/R3tvhPqvJvwcKfnBHJwwthS11LRhmM5D59eEXa0s=
 golang.org/x/sys v0.9.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"bytes"
 	"crypto/ed25519"
+	"crypto/sha512"
 	_ "embed"
 	"encoding/hex"
 	"errors"
@@ -75,22 +76,21 @@ func signFile(signer tkeysign.Signer, pubkey []byte, fileName string) ([]byte, e
 		return nil, fmt.Errorf("could not read %s: %w", fileName, err)
 	}
 
-	if len(message) > tkeysign.MaxSignSize {
-		return nil, fmt.Errorf("message too long, max is %d bytes", tkeysign.MaxSignSize)
-	}
+	fileDigest := sha512.Sum512(message)
+	le.Printf("SHA512 hash: %x\n", fileDigest)
 
-	le.Printf("Sending a %v bytes message for signing.\n", len(message))
 	if signerAppNoTouch == "" {
 		le.Printf("The TKey will flash green when touch is required ...\n")
 	} else {
 		le.Printf("WARNING! This tkey-sign and signer app is built with the touch requirement removed\n")
 	}
-	signature, err := signer.Sign(message)
+
+	signature, err := signer.Sign(fileDigest[:])
 	if err != nil {
 		return nil, fmt.Errorf("signing failed: %w", err)
 	}
 
-	if !ed25519.Verify(pubkey, message, signature) {
+	if !ed25519.Verify(pubkey, fileDigest[:], signature) {
 		return nil, fmt.Errorf("signature FAILED verification")
 	}
 
@@ -115,14 +115,13 @@ func fileInputToHex(inputFile string) ([]byte, error) {
 
 // verifySignature verifies a Ed25519 signature from input files of message, signature and public key
 func verifySignature(fileMessage string, fileSignature string, filePubkey string) error {
-	message, err := os.ReadFile(fileMessage)
-	if err != nil {
-		return fmt.Errorf("could not read %s: %w", fileMessage, err)
-	}
-
 	signature, err := fileInputToHex(fileSignature)
 	if err != nil {
 		return fmt.Errorf("decodeFileInput: %w", err)
+	}
+
+	if len(signature) != 64 {
+		return fmt.Errorf("invalid length of signature. Expected 64 bytes, got %d bytes", len(signature))
 	}
 
 	pubkey, err := fileInputToHex(filePubkey)
@@ -130,11 +129,22 @@ func verifySignature(fileMessage string, fileSignature string, filePubkey string
 		return fmt.Errorf("decodeFileInput: %w", err)
 	}
 
+	if len(pubkey) != 32 {
+		return fmt.Errorf("invalid length of public key. Expected 32 bytes, got %d bytes", len(pubkey))
+	}
+
 	fmt.Printf("Public key: %x\n", pubkey)
 	fmt.Printf("Signature: %x\n", signature)
-	fmt.Printf("Message length: %d\n", len(message))
 
-	if !ed25519.Verify(pubkey, message, signature) {
+	message, err := os.ReadFile(fileMessage)
+	if err != nil {
+		return fmt.Errorf("could not read %s: %w", fileMessage, err)
+	}
+
+	digest := sha512.Sum512(message)
+	le.Printf("SHA512 hash: %x\n", digest)
+
+	if !ed25519.Verify(pubkey, digest[:], signature) {
 		return fmt.Errorf("signature not valid")
 	}
 
@@ -243,11 +253,12 @@ func main() {
 	// Default text to show
 	root := pflag.NewFlagSet("root", pflag.ExitOnError)
 	root.Usage = func() {
-		desc := fmt.Sprintf(`%[1]s communicates with the signer app running on Tillitis TKey and
-makes it sign data provided in FILE (the "message"). The message can be at most
-4096 bytes long. The signature made by the signer app is always output on stdout.
-Exit status code is 0 if everything went well and the signature also can be
-verified using the public key. Otherwise exit code is non-zero.
+		desc := fmt.Sprintf(`%[1]s signs the data provided in FILE (the "message")
+using the Tillitis TKey. The message will be hashed using
+SHA512 and signed with Ed25519 using the TKey's private key.
+
+It is also possible to verify signatures with this tool, provided
+the message, signature and public key.
 
 Usage:
   %[1]s <command> [flags] FILE...
@@ -279,11 +290,12 @@ Use <command> --help for further help, i.e. %[1]s verify --help`, os.Args[0])
 	cmdSign.Usage = func() {
 		desc := fmt.Sprintf(`Usage: %[1]s sign [flags...] FILE
 
-  Signes the data provided in FILE (the "message") using the Tillitis TKey.
-  The message can be at most 4096 bytes long. The signature made by the signer
-  app is always output on stdout. Exit status code is 0 if everything went well
-  and the signature also can be verified using the public key. Otherwise exit
-  code is non-zero.
+  Signs the data provided in FILE (the "message"). The message will be
+  hashed with SHA512 and signed with Ed25519 using the TKey's private key.
+
+  The signature is always output on stdout. Exit status code is 0 if everything
+  went well and the signature can be verified using the public key. Otherwise
+  exit code is non-zero.
 
   Alternatively, --show-pubkey can be used to only output (on stdout) the
   public key of the signer app on the TKey.`, os.Args[0])
@@ -293,15 +305,19 @@ Use <command> --help for further help, i.e. %[1]s verify --help`, os.Args[0])
 
 	// Flag for command "verify"
 	cmdVerify := pflag.NewFlagSet(verifyString, pflag.ExitOnError)
+	cmdVerify.SortFlags = false
 	cmdVerify.BoolVarP(&helpOnlyVerify, "help", "h", false, "Output this help.")
 	cmdVerify.Usage = func() {
 		desc := fmt.Sprintf(`Usage: %[1]s verify FILE SIG-FILE PUBKEY-FILE
 
-  Verifies wheather the Ed25519 signature of the FILE is valid, based on the input files
-  SIG-FILE and PUBKEY-FILE. Newlines will be striped from the input files. The return value
-  is zero if the signature is valid, otherwise non-zero.
+  Verifies wheather the Ed25519 signature of the message is valid
+  using the public key. Does not need a connected TKey to verify.
 
-  Does not need a connected TKey to verify.`, os.Args[0])
+  SIG-FILE is expected to be an 64 bytes Ed25519 signature in hex.
+  PUBKEY-FILE is expected to be an 64 bytes Ed25519 public key in hex.
+
+  The return value is 0 if the signature is valid, otherwise non-zero.
+  Newlines will be striped from the input files. `, os.Args[0])
 		le.Printf("%s\n\n%s", desc,
 			cmdVerify.FlagUsagesWrapped(86))
 	}


### PR DESCRIPTION
After discussion with Rasmus & Nisse we decided to go with pure Ed25519 signing of our own digest. I took branch add_ph_sign and used it with the pure functions instead, squashed the commits.

Please review and test.
