### PR TITLE
Provide new command -F to get firmware digest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,3 +22,5 @@ require (
 	golang.org/x/sys v0.14.0 // indirect
 	golang.org/x/term v0.14.0 // indirect
 )
+
+replace github.com/tillitis/tkeysign => ../tkeysign


### PR DESCRIPTION
Test code for https://github.com/tillitis/tkeysign/pull/3

CI doesn't pass because of "replace" in go.mod, obviously. Use this to test the other PR. Then let's consider if we want to keep this functionality.

Note: Hardcoded length of firmware!

Also, don't use the embedded signer. Load a new signer with firmware command with tkey-runapp before.