### PR TITLE
Don't include VCS data in binaries

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,6 +25,7 @@ builds:
       - arm64
     flags:
       - -trimpath
+      - -buildvcs=false
 
     # Custom ldflags mostly to avoid setting main.date which for some
     # reason is default
@@ -46,6 +47,7 @@ builds:
       - arm64
     flags:
       - -trimpath
+      - -buildvcs=false
 
     # Custom ldflags mostly to avoid setting main.date which for some
     # reason is default
@@ -67,6 +69,7 @@ builds:
       - arm64
     flags:
       - -trimpath
+      - -buildvcs=false
 
     # Custom ldflags mostly to avoid setting main.date which for some
     # reason is default

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ TKEY_SIGN_VERSION ?= $(shell git describe --dirty --always | sed -n "s/^v\(.*\)/
 # .PHONY to let go-build handle deps and rebuilds
 .PHONY: tkey-sign
 tkey-sign:
-	CGO_ENABLED=$(BUILD_CGO_ENABLED) go build -ldflags "-w -X main.version=$(TKEY_SIGN_VERSION) -X main.signerAppNoTouch=$(TKEY_SIGNER_APP_NO_TOUCH)  -buildid=" -trimpath -o tkey-sign ./cmd/tkey-sign
+	CGO_ENABLED=$(BUILD_CGO_ENABLED) go build -ldflags "-w -X main.version=$(TKEY_SIGN_VERSION) -X main.signerAppNoTouch=$(TKEY_SIGNER_APP_NO_TOUCH)  -buildid=" -trimpath -buildvcs=false -o tkey-sign ./cmd/tkey-sign
 
 .PHONY: tkey-sign.exe
 tkey-sign.exe:


### PR DESCRIPTION
Let's not include the status of the Git checkout directory in the compiled binaries. Especially the thing about the dirty directory with untracked files bites us all the time.