### PR TITLE
Bug: Normalize line endings of user input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,18 +2,7 @@
 *.o
 *.bin
 *.elf
-/tkey-ssh-agent
-/tkey-ssh-agent.exe
-/cmd/tkey-ssh-agent/rsrc_windows_amd64.syso
-/tkey-ssh-agent-tray.exe
-/cmd/tkey-ssh-agent-tray/rsrc_windows_amd64.syso
-/tkey-runapp
 /tkey-sign
-/runsign.sh
-/runtimer
-/runrandom
-/gotools/golangci-lint
-/gotools/go-winres
-test/venv
+/tkey-sign.exe
 
 dist/

--- a/cmd/tkey-sign/file.go
+++ b/cmd/tkey-sign/file.go
@@ -120,7 +120,11 @@ func writeRetry(filename string, data any, comment string) error {
 		le.Printf("File %v exists. Overwrite [y/n]?", filename)
 		reader := bufio.NewReader(os.Stdin)
 		overWriteP, _ := reader.ReadString('\n')
-		if overWriteP == "y\n" {
+
+		// Trim space to normalize Windows line endings
+		overWriteP = strings.TrimSpace(overWriteP)
+
+		if overWriteP == "y" {
 			err = writeBase64(filename, data, comment, true)
 		} else {
 			le.Printf("Aborted\n")


### PR DESCRIPTION
## Description

Fixes issue #20, where the if statement always evaluated to false due to different line endings in Windows, `\r\n`.

Fixes # (issues)

## Type of change
- [x] Bugfix (non breaking change which resolve an issue)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [x] My changes are well written and CI is passing
