### PR TITLE
Handle TKey Unlocked like Bellatrix

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,14 +14,12 @@ linters:
     - fatcontext
     - gocheckcompilerdirectives
     - gochecksumtype
-    - gocyclo
     - godox
     - gomoddirectives
     - gomodguard
     - gosec
     - gosmopolitan
     - loggercheck
-    - maintidx
     - makezero
     - misspell
     - musttag
@@ -52,9 +50,11 @@ linters:
     - exhaustruct
     - funlen
     - gocognit
+    - gocyclo
     - godot
     - nestif
     - perfsprint
+    - maintidx
     - noctx
     # enable later
     - gocritic

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,16 @@
 # Release notes
 
+## v1.1.1
+
+- Update tkeyclient to v1.3.1 to handle TKey Unlocked (product ID 8)
+  as a Bellatrix when it comes to USS digest handling.
+
+- Only allow `--force-full-uss` when either `--uss` or `--uss-file` is
+  used.
+
+Full
+[changelog](https://github.com/tillitis/tkey-sign-cli/compare/v1.1.0...v1.1.1).
+
 ## v1.1.0
 
 - Update tkeyclient version because of a vulnerability leaving some

--- a/cmd/tkey-sign/main.go
+++ b/cmd/tkey-sign/main.go
@@ -372,6 +372,16 @@ func main() {
 			os.Exit(1)
 		}
 
+		if *enterUss && *ussFile != "" {
+			le.Printf("Pass only one of --uss or --uss-file.\n\n")
+			os.Exit(1)
+		}
+
+		if *forceFullUss && *ussFile == "" != *enterUss {
+			le.Printf("--force-full-uss unusable unless you also specify --uss or --uss-file.\n\n")
+			os.Exit(1)
+		}
+
 		signer, pub, err := loadSigner(*devPath, *speed, *ussFile, *enterUss, *forceFullUss)
 		if err != nil {
 			le.Printf("Couldn't load signer: %v", err)
@@ -419,6 +429,16 @@ func main() {
 		pubkey, err := readKey(*keyFile)
 		if err != nil {
 			le.Printf("Couldn't read pubkey file: %v", err)
+			os.Exit(1)
+		}
+
+		if *enterUss && *ussFile != "" {
+			le.Printf("Pass only one of --uss or --uss-file.\n\n")
+			os.Exit(1)
+		}
+
+		if *forceFullUss && *ussFile == "" != *enterUss {
+			le.Printf("--force-full-uss unusable unless you also specify --uss or --uss-file.\n\n")
 			os.Exit(1)
 		}
 

--- a/doc/tkey-sign.1
+++ b/doc/tkey-sign.1
@@ -5,7 +5,7 @@
 .nh
 .ad l
 .\" Begin generated content:
-.TH "tkey-sign" "1" "2026-03-16"
+.TH "tkey-sign" "1" "2026-03-23"
 .PP
 .SH NAME
 .PP
@@ -77,6 +77,8 @@ Force writing signature and pubkey file, overwriting existing files.\&
 .RS 4
 Force sending a 32 byte USS digest.\& For backwards compatibility
 the default is sending 31 bytes of the computed digest and a zero.\&
+.PP
+Only usable with \fB--uss\fR or \fB--uss-file\fR.\&
 .PP
 .RE
 \fB-h, --help\fR

--- a/doc/tkey-sign.scd
+++ b/doc/tkey-sign.scd
@@ -60,6 +60,8 @@ when signing or extracting the public key.
 	Force sending a 32 byte USS digest. For backwards compatibility
 	the default is sending 31 bytes of the computed digest and a zero.
 
+	Only usable with *--uss* or *--uss-file*.
+
 *-h, --help*
 
 	Output short help text.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.1
 
 require (
 	github.com/spf13/pflag v1.0.5
-	github.com/tillitis/tkeyclient v1.3.0
+	github.com/tillitis/tkeyclient v1.3.1
 	github.com/tillitis/tkeysign v1.0.1
 	github.com/tillitis/tkeyutil v0.0.9
 )

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/tadvi/systray v0.0.0-20190226123456-11a2b8fa57af h1:6yITBqGTE2lEeTPG0
 github.com/tadvi/systray v0.0.0-20190226123456-11a2b8fa57af/go.mod h1:4F09kP5F+am0jAwlQLddpoMDM+iewkxxt6nxUQ5nq5o=
 github.com/tillitis/tkeyclient v1.3.0 h1:fUlghD+xvtL+qoajgrsetCC7KPwSfpjDDgqxMOBA2VU=
 github.com/tillitis/tkeyclient v1.3.0/go.mod h1:7VtzyEjm08Wf+1zdrs20HsvM+WzhyztinvGG2/HY+Is=
+github.com/tillitis/tkeyclient v1.3.1 h1:IouMAtwwXewhXLmcySBmXuyFuI4WoAw8NQj+gFWlLaw=
+github.com/tillitis/tkeyclient v1.3.1/go.mod h1:7VtzyEjm08Wf+1zdrs20HsvM+WzhyztinvGG2/HY+Is=
 github.com/tillitis/tkeysign v1.0.1 h1:E+nycj/iv9247MOBval1PmWcZ68J7LUXhXdlW49+N08=
 github.com/tillitis/tkeysign v1.0.1/go.mod h1:C4gYuqI2HHJ86S0PoWlk30eFsKDnMvdEgIYIVyNfzvY=
 github.com/tillitis/tkeyutil v0.0.9 h1:WWF4Emxch32TczYjjYwl45GMtxsD9l8432mZaX6u8mw=


### PR DESCRIPTION
## Description

- Update tkeyclient to v1.3.1 to get Bellatrix behaviour on TKey Unlocked.
- Only allow --force-full-uss with --uss or --uss-file

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [x] Bugfix (non breaking change which resolve an issue)

## Submission checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
