### PR TITLE
Refactor comment writing to use fmt.Appendf

### DIFF
--- a/cmd/tkey-sign/file.go
+++ b/cmd/tkey-sign/file.go
@@ -99,7 +99,7 @@ func writeBase64(filename string, data any, comment string, overwrite bool) erro
 
 	defer f.Close()
 
-	_, err = f.Write([]byte(fmt.Sprintf("untrusted comment: %s\n", comment)))
+	_, err = f.Write(fmt.Appendf(nil, "untrusted comment: %s\n", comment))
 	if err != nil {
 		return fmt.Errorf("%w", err)
 	}


### PR DESCRIPTION
Before: `fmt.Sprintf` first allocates a string, then `[]byte(...)` copies that string data into a newly allocated byte slice.

After: `fmt.Appendf(nil, ...)` formats the arguments directly into a `[]byte`, skipping the temporary string entirely.
