### PR TITLE
Add raw pubkey output

### DIFF
--- a/cmd/tkey-sign/main.go
+++ b/cmd/tkey-sign/main.go
@@ -291,6 +291,13 @@ func GetKey(keyFn string, overwrite bool, dev devArgs, uss USSArgs) error {
 	if err != nil {
 		return fmt.Errorf("%w", err)
 	}
+	// Proof of concept.
+	binPath := keyFn + ".bin"
+	err = pubkey.ToFileRaw(binPath, true)
+
+	if err != nil {
+		return fmt.Errorf("%w", err)
+	}
 
 	return nil
 }

--- a/signify/signify.go
+++ b/signify/signify.go
@@ -140,6 +140,10 @@ func (p *PubKey) ToFile(fileName string, comment string, overwrite bool) error {
 	return writeFile(fileName, buf, overwrite)
 }
 
+func (p *PubKey) ToFileRaw(fileName string, overwrite bool) error {
+	return writeFile(fileName, p[:], overwrite)
+}
+
 // NewSignature instantiates a signify Signature from a byte slice.
 func NewSignature(t AlgType, srcSig []byte) (Signature, error) {
 	var sig Signature


### PR DESCRIPTION
## Description
A proof of concept to be able to export the public key in raw format.
The method in the signify package is well written, but the usage in main.go is just to show that it works.
It will write to the <pubkeyfile>.bin where pubkeyfile is the signify formated pubkey (-p).

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.
- [x] Feature (non breaking change which adds functionality)

## Submission checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
